### PR TITLE
DP-21: Feat: Configure API URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
             }
         ],
         "configuration": {
-            "title": "SIGIL-PS Personalization",
+            "title": "SIGIL-PS Settings",
             "properties": {
                 "sigil.persona": {
                     "type": "string",
@@ -69,6 +69,18 @@
                     "type": "boolean",
                     "default": false,
                     "description": "When this option is set to true, you consent that your interactions with SIGIL-PS may be anonymously collected for research purposes and written about in written research that will be publicly available. To reiterate, none of the collected data will contain identifying information about you, and no identifying information about you will appear in written reports. This data will include\n\n- your prompts,\n- the code you have open in VS Code, and\n- the chatbot's responses \n\nAdditionally, we will collect basic identifying information from the public GitHub profile you are using with the SIGIL-PS. This data will not be publicly disclosed. This data will include your\n\n- username, \n- full name, and\n-email"
+                },
+                "sigil.developerSettings.test": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "machine",
+                    "description": "Development setting: when enabled, SIGIL-PS will use the test environment for the backend."
+                },
+                "sigil.developerSettings.apiUrl": {
+                    "type": "string",
+                    "default": "",
+                    "scope": "machine",
+                    "description": "Development setting: custom base URL for the SIGIL-PS API for testing purposes (i.e. localhost). Only applies when in test environment."
                 }
             }
         }

--- a/src/apiConfig.ts
+++ b/src/apiConfig.ts
@@ -1,0 +1,16 @@
+import * as vscode from 'vscode';
+
+const TEST_URL = 'https://sigil-api-test.lemonsand-c67bbaad.westus2.azurecontainerapps.io';
+const PROD_URL = 'https://sigil-api.lemonsand-c67bbaad.westus2.azurecontainerapps.io';
+
+export default function getApiUrl() {
+    const config = vscode.workspace.getConfiguration();
+    const useTest = config.get<boolean>('sigil.developerSettings.test');
+    const customUrl = config.get<string>('sigil.developerSettings.apiUrl');
+
+    if (useTest) {
+        return customUrl && customUrl.trim() !== '' ? customUrl : TEST_URL;
+    }
+
+    return PROD_URL;
+}

--- a/src/config.template.ts
+++ b/src/config.template.ts
@@ -1,3 +1,0 @@
-const apiUrl = '';
-
-export default apiUrl;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import {v4 as uuidv4} from 'uuid';
 import {authenticateWithGitHub} from './auth';
 import {syncPersonalization, updatePersonalization} from './personalization';
-import apiUrl from "./config";
+import getApiUrl from "./apiConfig";
 
 const MAX_HISTORY_LENGTH = 6;
 const GOOD = 1;
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
             let config = vscode.workspace.getConfiguration();
             let personalize = config.get<boolean>("sigil.personalizeResponses");
 
-            const apiResponse = await post(`${apiUrl}/api/feedback`, {rating: ratingEnum, reason: customReason, personalize, ...args});
+            const apiResponse = await post(`${getApiUrl()}/api/feedback`, {rating: ratingEnum, reason: customReason, personalize, ...args});
             console.log('API Response:', apiResponse.data);
             
             if (personalize) {
@@ -199,7 +199,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             // get Sigil response
-            const apiResponse = await post(`${apiUrl}/api/prompt`, 
+            const apiResponse = await post(`${getApiUrl()}/api/prompt`, 
                 {userID: githubUser?.id, conversationID: conversationId, 
                     code, message: request.prompt, history, personalize, persona, logChat,
                     userMetaData: {
@@ -252,6 +252,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Allow user to manage personalization
     context.subscriptions.push(
         vscode.commands.registerCommand('sigil-ps.openPersonalization', async () => {
+            console.log("API URL:", getApiUrl());
             vscode.window.showInformationMessage('Opening Sigil Personalization settings...');
 
             await syncPersonalization(context);

--- a/src/personalization.ts
+++ b/src/personalization.ts
@@ -1,4 +1,4 @@
-import apiUrl from "./config";
+import getApiUrl from "./apiConfig";
 import { authenticateWithGitHub } from "./auth";
 import {AxiosError, get, put} from "axios";
 import * as vscode from 'vscode';
@@ -13,7 +13,7 @@ export async function syncPersonalization(context: vscode.ExtensionContext) {
             return;
         }
 
-        const result = await get(`${apiUrl}/api/personalization/${githubUser.id}`);
+        const result = await get(`${getApiUrl()}/api/personalization/${githubUser.id}`);
         const personalization = result.data.personalization || {"personalizedPrompt": ""};
 
         const config = vscode.workspace.getConfiguration();
@@ -37,7 +37,7 @@ export async function updatePersonalization(context: vscode.ExtensionContext, ne
             return;
         }
 
-        await put(`${apiUrl}/api/personalization/${githubUser.id}`, { personalization: { personalizedPrompt: newPersonalization } });
+        await put(`${getApiUrl()}/api/personalization/${githubUser.id}`, { personalization: { personalizedPrompt: newPersonalization } });
         vscode.window.showInformationMessage("Sigil: Personalization settings updated successfully");
     } catch (error) {
         vscode.window.showErrorMessage("Sigil: Error updating personalization settings");


### PR DESCRIPTION
We now point to the production API URL by default, and also expose developer settings to use the test API, as well as set a custom URL (i.e. localhost)